### PR TITLE
Make readTimeout to fetch artifacts configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Versioning](https://semver.org/), namely:
 ` previousArtifact` | `latest-release` | If set to `latest-release`, will attempt to determine the most recent released version as described above; otherwise, this can be set to a specific version of an artifact. |
 | `failOnProblem` | `semver` | If set to `semver`, the previous artifact version is compared with the current version, and whether or not incompatibilities will cause the build to fail is decided based on Semantic Versioning rules, as described above.  If set to `never` or `false`, binary incompatibilities are never allowed, while `always` or `true` will put the plugin into warn-only mode. |
 | `failOnNoPrevious` | `false` | Whether or not to fail the build if a previous artifact version is not supplied or cannot be found. |
+| `readTimeout` | `4000` | Timeout in ms to fetch the previous artifact. |
 | `direction` | `backward` | Whether to do `backward` compatibilities checks, `forward` compatibility checks, or `both`. |
 | `filters` | (none) | A list of `<filter>` elements that allow you to ignore particular problems (see below). |
 

--- a/src/main/scala/org/spurint/maven/plugins/mima/MiMaMojo.scala
+++ b/src/main/scala/org/spurint/maven/plugins/mima/MiMaMojo.scala
@@ -78,6 +78,9 @@ class MiMaMojo extends AbstractMojo {
   @Parameter(property = "mima.skip", defaultValue = "false")
   private var skip: Boolean = false
 
+  @Parameter(property = "readTimeout", defaultValue = "4000")
+  private var readTimeout: Int = 4000
+
   @Parameter(defaultValue = "${project.build.outputDirectory}", required = true, readonly = true)
   private var buildOutputDirectory: File = _
 
@@ -241,7 +244,7 @@ class MiMaMojo extends AbstractMojo {
         case x => throw new AssertionError(s"${x.getClass.getName} should be a HttpURLConnection")
       }
       conn.setConnectTimeout(2000)
-      conn.setReadTimeout(4000)
+      conn.setReadTimeout(readTimeout)
       conn.getResponseCode match {
         case x if x >= 200 && x < 300 =>
           Option(conn.getInputStream)


### PR DESCRIPTION
That can be useful behind a Nexus with lot of artifacts.

I have the problem with a nexus having so many artifacts that it takes sometimes around 10s when the artifact is not in its cache.